### PR TITLE
V0.2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ nbrmd.egg-info
 nbrmd.Rproj
 *.pyc
 gits*
+.ipynb_checkpoints

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,20 @@ Release History
 dev
 +++
 
+0.2.4 (2018-07-05)
++++++++++++++++++++
+
+**Improvements**
+
+- nbrmd will always open notebooks, even if header of code cells are not terminated. Merge conflicts can thus be
+solved in Jupyter directly.
+- New metadata 'main language' that preserves the notebook language.
+
+**BugFixes**
+
+- dependencies included in `setup.py`
+- pre_save_hook work with non-empty `notebook_dir` `#9<https://github.com/mwouts/nbrmd/issues/9>`_
+
 0.2.3 (2018-06-28)
 +++++++++++++++++++
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,6 @@ include *.ini
 include *.rst
 exclude .gitignore
 exclude .gitreview
+include img
 
 global-exclude *.pyc

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You will be interested in this if
 
 ## What is R markdown?
 
-As the name states, R markdown (extension `.Rmd`) was designed in the R community. It is the format used by the RStudio IDE for notebooks. It actually support [many languages](https://yihui.name/knitr/demo/engines/). A few months back, the support for python significantly improved with the arrival of the [`reticulate`](https://github.com/rstudio/reticulate) package.
+R markdown (extension `.Rmd`) is a well established markdown [notebook format](https://rmarkdown.rstudio.com/). As the name states, R markdown was designed in the R community, but it actually support [many languages](https://yihui.name/knitr/demo/engines/). A few months back, the support for python significantly improved with the arrival of the [`reticulate`](https://github.com/rstudio/reticulate) package.
 
 R markdown is almost identical to markdown export of Jupyter notebooks. For reference, Jupyter notebooks are exported to markdown using either
 - _Download as Markdown (.md)_ in Jupyter's interface,

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Accepted formats are: `.ipynb`, `.Rmd` and `.md`.
 ### Global configuration
 
 If you want every notebook to be saved as both `.Rmd` and `.ipynb` files, then change your jupyter config to
- ```python
+```python
 c.NotebookApp.contents_manager_class = 'nbrmd.RmdFileContentsManager'
 c.ContentsManager.pre_save_hook = 'nbrmd.update_rmd_and_ipynb'
 ```

--- a/nbrmd/hooks.py
+++ b/nbrmd/hooks.py
@@ -3,7 +3,8 @@ import nbrmd
 import nbformat
 
 
-def update_rmd_and_ipynb(model, path, format=['.ipynb', '.Rmd'], **kwargs):
+def update_rmd_and_ipynb(model, path, contents_manager=None,
+                         format=['.ipynb', '.Rmd'], **kwargs):
     """
     A pre-save hook for jupyter that saves the notebooks
     under the alternative form.
@@ -11,6 +12,7 @@ def update_rmd_and_ipynb(model, path, format=['.ipynb', '.Rmd'], **kwargs):
     When the notebook has extension '.Rmd', this creates a '.ipynb' file
     :param model: data model, that may contain the notebook
     :param path: full name for ipython notebook
+    :param contents_manager: ContentsManager instance
     :param format: list of alternative formats
     :param kwargs: not used
     :return:
@@ -28,48 +30,60 @@ def update_rmd_and_ipynb(model, path, format=['.ipynb', '.Rmd'], **kwargs):
     format = nb.get('metadata', {}).get('nbrmd_formats', format)
     if not isinstance(format, list) or not set(format).issubset(
             ['.Rmd', '.md', '.ipynb']):
-        raise TypeError("Notebook metadata 'nbrmd_formats' "
-                        "should be subset of ['.Rmd', '.md', '.ipynb']")
+        raise TypeError(u"Notebook metadata 'nbrmd_formats' "
+                        u"should be subset of ['.Rmd', '.md', '.ipynb']")
 
+    os_path = contents_manager._get_os_path(path) if contents_manager else path
     file, ext = os.path.splitext(path)
+    os_file, ext = os.path.splitext(os_path)
 
     for alt_ext in format:
         if ext != alt_ext:
-            nbrmd.writef(nbformat.notebooknode.from_dict(nb), file + alt_ext)
+            if contents_manager:
+                contents_manager.log.info(
+                    u"Saving file at /%s", file + alt_ext)
+            nbrmd.writef(nbformat.notebooknode.from_dict(nb),
+                         os_file + alt_ext)
 
 
-def update_rmd(model, path, **kwargs):
+def update_rmd(model, path, contents_manager=None, **kwargs):
     """
     A pre-save hook for jupyter that saves the notebooks in '.Rmd' format when
     the notebook has extension '.ipynb'
     :param model: data model, that may contain the notebook
     :param path: full name for ipython notebook
+    :param contents_manager: ContentsManager instance
     :param kwargs: not used
     :return:
     """
-    update_rmd_and_ipynb(model, path, format=['.Rmd'], **kwargs)
+    update_rmd_and_ipynb(model, path, contents_manager, format=['.Rmd'],
+                         **kwargs)
 
 
-def update_ipynb(model, path, **kwargs):
+def update_ipynb(model, path, contents_manager=None, **kwargs):
     """
     A pre-save hook for jupyter that saves the notebooks in '.Rmd' format when
     the notebook has extension '.ipynb'
     :param model: data model, that may contain the notebook
     :param path: full name for ipython notebook
+    :param contents_manager: ContentsManager instance
     :param kwargs: not used
     :return:
     """
-    update_rmd_and_ipynb(model, path, format=['.ipynb'], **kwargs)
+    update_rmd_and_ipynb(model, path, contents_manager, format=['.ipynb'],
+                         **kwargs)
 
 
-def update_selected_formats(model, path, **kwargs):
+def update_selected_formats(model, path, contents_manager=None, **kwargs):
     """
     A pre-save hook for jupyter that saves the notebooks in the formats
     selected in notebook metadata 'nbrmd_formats', that should be a list
     :param model: data model, that may contain the notebook
     :param path: full name for ipython notebook
+    :param contents_manager: ContentsManager instance
     :param kwargs: not used
     :return:
     """
 
-    update_rmd_and_ipynb(model, path, format=[], **kwargs)
+    update_rmd_and_ipynb(model, path, contents_manager=None, format=[],
+                         **kwargs)

--- a/nbrmd/nbrmd.py
+++ b/nbrmd/nbrmd.py
@@ -178,13 +178,13 @@ class RmdReader(NotebookReader):
         main_language = (metadata.get('main_language') or
                          metadata.get('language_info', {}).get('name'))
         if main_language is None:
-            languages = dict(python=0)
+            languages = dict(python=0.5)
             for c in cells:
                 if c['cell_type'] == 'code':
                     language = c['metadata']['language']
                     if language == 'r':
                         language = 'R'
-                    languages[language] = languages.get(language, 0) + 1
+                    languages[language] = languages.get(language, 0.0) + 1
 
             main_language = max(languages, key=languages.get)
 
@@ -228,7 +228,7 @@ class RmdWriter(NotebookWriter):
                 del metadata['main_language']
             # is 'main language' redundant with cell language?
             elif metadata.get('language_info', {}).get('name') is None:
-                languages = dict(python=0)
+                languages = dict(python=0.5)
                 for c in nb.cells:
                     if c.cell_type == 'code':
                         input = c.source.splitlines()
@@ -243,7 +243,7 @@ class RmdWriter(NotebookWriter):
                             language = 'R'
 
                         languages[language] = 1 + languages.get(
-                            language, 0)
+                            language, 0.0)
 
                 cell_main_language = max(languages, key=languages.get)
                 if metadata['main_language'] == cell_main_language:

--- a/nbrmd/nbrmd.py
+++ b/nbrmd/nbrmd.py
@@ -32,7 +32,8 @@ from .chunk_options import to_metadata, to_chunk_options
 
 def _language(metadata):
     try:
-        return metadata.language_info.name.lower()
+        return metadata.get('main_language') or \
+               metadata.language_info.name.lower()
     except AttributeError:
         return u'python'
 
@@ -53,10 +54,6 @@ _jupyter_languages_re = [re.compile(r"^%%{}\s*".format(lang))
                          for lang in _jupyter_languages]
 
 
-class RmdReaderError(Exception):
-    pass
-
-
 class RmdReader(NotebookReader):
 
     def __init__(self, markdown=False):
@@ -73,21 +70,21 @@ class RmdReader(NotebookReader):
         cells = []
         cell_lines = []
 
-        def add_markdown_cell():
+        def add_cell(new_cell=new_markdown_cell):
             if len(cell_lines) == 0:
                 return
 
             if cell_lines[-1] == '':
                 if len(cell_lines) > 1 or len(cells) == 0:
-                    cells.append(new_markdown_cell(
+                    cells.append(new_cell(
                         source=u'\n'.join(cell_lines[:-1])))
                 else:
                     cells[-1]['metadata']['noskipline'] = True
-                    cells.append(new_markdown_cell(
+                    cells.append(new_cell(
                         source=u'\n'.join(cell_lines)))
             else:
-                cells.append(new_markdown_cell(source=u'\n'.join(cell_lines),
-                                               metadata={u'noskipline': True}))
+                cells.append(new_cell(source=u'\n'.join(cell_lines),
+                                      metadata={u'noskipline': True}))
 
         cell_metadata = {}
         state = State.NONE
@@ -101,6 +98,18 @@ class RmdReader(NotebookReader):
                 state = State.MARKDOWN
 
             if state is State.HEADER:
+                # Unterminated header -> treat first lines as raw
+                if self.start_code_re.match(line):
+                    cell_lines = ['---'] + cell_lines
+                    add_cell(new_cell=new_raw_cell)
+                    cell_lines = []
+
+                    chunk_options = self.start_code_re.findall(line)[0]
+                    language, cell_metadata = to_metadata(chunk_options)
+                    cell_metadata['language'] = language
+                    state = State.CODE
+                    continue
+
                 if _header_re.match(line):
                     header = []
                     jupyter = []
@@ -134,7 +143,7 @@ class RmdReader(NotebookReader):
 
             if state is State.MARKDOWN:
                 if self.start_code_re.match(line):
-                    add_markdown_cell()
+                    add_cell()
                     cell_lines = []
 
                     chunk_options = self.start_code_re.findall(line)[0]
@@ -157,14 +166,17 @@ class RmdReader(NotebookReader):
 
         # Append last cell if not empty
         if state is State.MARKDOWN:
-            add_markdown_cell()
+            add_cell()
         elif state is State.CODE:
-            raise RmdReaderError(u'Unterminated code cell')
+            cells.append(new_code_cell(source=u'\n'.join(cell_lines),
+                                       metadata=cell_metadata))
         elif state is State.HEADER:
-            raise RmdReaderError(u'Unterminated YAML header')
+            cell_lines = ['---'] + cell_lines
+            add_cell(new_cell=new_raw_cell)
 
         # Determine main language
-        main_language = metadata.get('language_info', {}).get('name')
+        main_language = (metadata.get('main_language') or
+                         metadata.get('language_info', {}).get('name'))
         if main_language is None:
             languages = dict(python=0)
             for c in cells:
@@ -175,8 +187,11 @@ class RmdReader(NotebookReader):
                     languages[language] = languages.get(language, 0) + 1
 
             main_language = max(languages, key=languages.get)
-            metadata['language_info'] = metadata.get('language_info', {})
-            metadata['language_info']['name'] = main_language
+
+            # save main language when not given by kernel
+            if main_language is not \
+                    metadata.get('language_info', {}).get('name'):
+                metadata['main_language'] = main_language
 
         # Remove 'language' meta data and add a magic if not main language
         for c in cells:
@@ -205,6 +220,34 @@ class RmdWriter(NotebookWriter):
     def writes(self, nb):
         default_language = _language(nb.metadata)
         metadata = _as_dict(nb.metadata)
+
+        if 'main_language' in metadata:
+            # is 'main language' redundant with kernel info?
+            if metadata['main_language'] is \
+                    metadata.get('language_info', {}).get('name'):
+                del metadata['main_language']
+            # is 'main language' redundant with cell language?
+            elif metadata.get('language_info', {}).get('name') is None:
+                languages = dict(python=0)
+                for c in nb.cells:
+                    if c.cell_type == 'code':
+                        input = c.source.splitlines()
+                        language = default_language
+                        if len(input):
+                            for lang, pattern in zip(_jupyter_languages,
+                                                     _jupyter_languages_re):
+                                if pattern.match(input[0]):
+                                    language = lang
+
+                        if language == 'r':
+                            language = 'R'
+
+                        languages[language] = 1 + languages.get(
+                            language, 0)
+
+                cell_main_language = max(languages, key=languages.get)
+                if metadata['main_language'] == cell_main_language:
+                    del metadata['main_language']
 
         lines = []
         header_inserted = len(metadata) == 0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from nbrmd.nbrmd import readme
 
 setup(
     name='nbrmd',
-    version='0.2.3',
+    version='0.2.4',
     author='Marc Wouts',
     author_email='marc.wouts@gmail.com',
     description='Jupyter from/to R markdown notebooks',
@@ -17,7 +17,7 @@ setup(
     tests_require=['pytest'],
     install_requires=['nbformat>=4.0.0', 'mock', 'pyyaml'],
     license='MIT',
-    classifiers=('Development Status :: 3 - Alpha',
+    classifiers=('Development Status :: 4 - Beta',
                  'Environment :: Console',
                  'Framework :: Jupyter',
                  'Intended Audience :: Science/Research',

--- a/tests/R_sample.Rmd
+++ b/tests/R_sample.Rmd
@@ -1,9 +1,6 @@
 ---
 title: "R Notebook"
 output: html_notebook
-jupyter:
-  language_info:
-    name: R
 ---
 
 This is an [R Markdown](http://rmarkdown.rstudio.com) Notebook. When you execute code within the notebook, the results appear beneath the code. 

--- a/tests/ioslides.Rmd
+++ b/tests/ioslides.Rmd
@@ -9,9 +9,6 @@ output:
     smaller: true
 editor_options:
   chunk_output_type: console
-jupyter:
-  language_info:
-    name: python
 ---
 
 ## What is ioslides?
@@ -22,7 +19,7 @@ Enjoy the [manual](https://rmarkdown.rstudio.com/ioslides_presentation_format.ht
 
 These slides can be turned to a single HTML file with either a click on 'knitr' in rstudio, or, command line:
 ```bash
-R -e 'rmarkdown::render("simple.Rmd")'
+R -e 'rmarkdown::render("ioslides.Rmd")'
 ```
 
 ## A sample plot

--- a/tests/markdown.Rmd
+++ b/tests/markdown.Rmd
@@ -1,9 +1,3 @@
----
-jupyter:
-  language_info:
-    name: python
----
-
 # This is a plain markdown file
 
 ```python

--- a/tests/test_nbrmd_errors.py
+++ b/tests/test_nbrmd_errors.py
@@ -2,22 +2,6 @@ import nbrmd
 import pytest
 
 
-def test_parse_incomplete_code():
-    s = """```{python}
-1+1
-"""
-    with pytest.raises(nbrmd.nbrmd.RmdReaderError):
-        nbrmd.reads(s)
-
-
-def test_parse_incomplete_header():
-    s = """---
-title: Incomplete header
-"""
-    with pytest.raises(nbrmd.nbrmd.RmdReaderError):
-        nbrmd.reads(s)
-
-
 def test_read_wrong_ext(tmpdir, nb_file='notebook.ext'):
     nb_file = tmpdir.join('nb_file')
     nb_file.write('{}')

--- a/tests/test_open_readme.py
+++ b/tests/test_open_readme.py
@@ -1,0 +1,13 @@
+import nbrmd
+import pytest
+import os
+
+
+@pytest.fixture()
+def readme():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        '..', 'README.md')
+
+
+def test_open_readme(readme):
+    nb = nbrmd.readf(readme)

--- a/tests/test_read_incomplete_rmd.py
+++ b/tests/test_read_incomplete_rmd.py
@@ -1,0 +1,69 @@
+import nbrmd
+
+
+def test_incomplete_header(rmd="""---
+title: Incomplete header
+
+```{python}
+1+1
+```
+"""):
+    nb = nbrmd.reads(rmd)
+    assert len(nb.cells) == 2
+    assert nb.cells[0].cell_type == 'raw'
+    assert nb.cells[0].source == '---\ntitle: Incomplete header'
+    assert nb.cells[1].cell_type == 'code'
+    assert nb.cells[1].source == '1+1'
+
+
+def test_incomplete_code_chunk(rmd="""```{python}
+a = 1
+b = 2
+a + b
+```
+
+```
+
+```{bash}
+ls -l
+```
+"""):
+    nb = nbrmd.reads(rmd)
+    assert len(nb.cells) == 3
+    assert nb.cells[0].cell_type == 'code'
+    assert nb.cells[0].source == 'a = 1\nb = 2\na + b'
+    assert nb.cells[1].cell_type == 'markdown'
+    assert nb.cells[1].source == '```'
+    assert nb.cells[2].cell_type == 'code'
+    assert nb.cells[2].source == '%%bash\nls -l'
+
+
+def test_unterminated_header_and_unstarted_chunk(rmd="""---
+title: Unterminated header
+
+```{python}
+1+3
+```
+
+```
+
+```{r}
+1+4
+```
+
+```{python not_terminated}
+1+5
+"""):
+    nb = nbrmd.reads(rmd)
+    assert len(nb.cells) == 5
+    assert nb.cells[0].cell_type == 'raw'
+    assert nb.cells[0].source == '---\ntitle: Unterminated header'
+    assert nb.cells[1].cell_type == 'code'
+    assert nb.cells[1].source == '1+3'
+    assert nb.cells[2].cell_type == 'markdown'
+    assert nb.cells[2].source == '```'
+    assert nb.cells[3].cell_type == 'code'
+    assert nb.cells[3].source == '%%R\n1+4'
+    assert nb.cells[4].cell_type == 'code'
+    assert nb.cells[4].metadata == {'name': 'not_terminated'}
+    assert nb.cells[4].source == '1+5'


### PR DESCRIPTION
- nbrmd will always open notebooks, even if header of code cells are not terminated. Merge conflicts can thus be solved in Jupyter directly.
- New metadata 'main language' that preserves the notebook language.
- dependencies included in `setup.py`
- pre_save_hook fixed in case of non-empty `notebook_dir` #9